### PR TITLE
NOTICE disconnects and initializations, send SMS to local numbers, multi-line SMS via AMI

### DIFF
--- a/at_response.c
+++ b/at_response.c
@@ -199,7 +199,7 @@ static int at_response_ok (struct pvt* pvt, at_res_t res)
 				{
 					pvt->timeout = DATA_READ_TIMEOUT;
 					pvt->initialized = 1;
-					ast_verb (3, "[%s] Dongle initialized and ready\n", PVT_ID(pvt));
+					ast_log (LOG_NOTICE, "[%s] Dongle initialized and ready\n", PVT_ID(pvt));
 					manager_event_device_status(PVT_ID(pvt), "Initialize");
 				}
 				break;

--- a/chan_dongle.c
+++ b/chan_dongle.c
@@ -345,7 +345,7 @@ static void disconnect_dongle (struct pvt* pvt)
 	ast_copy_string (PVT_STATE(pvt, data_tty),  CONF_UNIQ(pvt, data_tty), sizeof (PVT_STATE(pvt, data_tty)));
 	ast_copy_string (PVT_STATE(pvt, audio_tty), CONF_UNIQ(pvt, audio_tty), sizeof (PVT_STATE(pvt, audio_tty)));
 
-	ast_verb (3, "[%s] Dongle has disconnected\n", PVT_ID(pvt));
+	ast_log (LOG_NOTICE, "[%s] Dongle has disconnected\n", PVT_ID(pvt));
 
 	manager_event_device_status(PVT_ID(pvt), "Disconnect");
 }

--- a/pdu.c
+++ b/pdu.c
@@ -209,6 +209,9 @@
 #define NUMBER_TYPE_INTERNATIONAL	(TP_A_EXT_NOEXT | TP_A_TON_INTERNATIONAL | TP_A_NPI_TEL_E164_E163) /* 0x91 */
 #define NUMBER_TYPE_NATIONAL		(TP_A_EXT_NOEXT | TP_A_TON_SUBSCRIBERNUM | TP_A_NPI_NATIONALNUM) /* 0xC8 */
 #define NUMBER_TYPE_ALPHANUMERIC	(TP_A_EXT_NOEXT | TP_A_TON_ALPHANUMERIC | TP_A_NPI_UNKNOWN) /* 0xD0 */
+/* maybe NUMBER_TYPE_NETWORKSHORT should be 0xB1 ??? */
+#define NUMBER_TYPE_NETWORKSHORT	(TP_A_EXT_NOEXT | TP_A_TON_NETSPECIFIC | TP_A_NPI_PRIVATENUM) /* 0xB9 */
+#define NUMBER_TYPE_UNKNOWN		(TP_A_EXT_NOEXT | TP_A_TON_UNKNOWN | TP_A_NPI_TEL_E164_E163) /* 0x81 */
 
 /* Message Type Indicator Parameter */
 #define PDUTYPE_MTI_SHIFT			0
@@ -578,7 +581,16 @@ EXPORT_DEF int pdu_build(char* buffer, size_t length, const char* sca, const cha
 		sca++;
 
 	if(dst[0] == '+')
+	{
 		dst++;
+	}
+	else
+	{
+		if(strlen(dst) < 6)
+			dst_toa=NUMBER_TYPE_NETWORKSHORT; //0xB9
+		else
+			dst_toa=NUMBER_TYPE_UNKNOWN; //0X81
+	}
 
 	/* count length of strings */
 	sca_len = strlen(sca);


### PR DESCRIPTION
- Send SMS to local and internal network numbers
- Log `NOTICE` when dongle disconnects or initializes
- Sending multi-line SMS via AMI (with `'\n'` or `'\r'`)