### PR TITLE
E3531s-2

### DIFF
--- a/at_command.c
+++ b/at_command.c
@@ -160,7 +160,7 @@ EXPORT_DEF int at_enqueue_initialization(struct cpvt *cpvt, at_cmd_t from_comman
 
 		ATQ_CMD_DECLARE_STI(CMD_AT_CREG_INIT,cmd14),	/* GSM registration status setting */
 		ATQ_CMD_DECLARE_ST(CMD_AT_CREG, cmd15),		/* GSM registration status */
-		ATQ_CMD_DECLARE_ST(CMD_AT_CNUM, cmd16),		/* Get Subscriber number */
+		ATQ_CMD_DECLARE_STI(CMD_AT_CNUM, cmd16),		/* Get Subscriber number */
 		ATQ_CMD_DECLARE_ST(CMD_AT_CVOICE, cmd17),	/* read the current voice mode, and return sampling rate、data bit、frame period */
 
 		ATQ_CMD_DECLARE_ST(CMD_AT_CSCA, cmd6),		/* Get SMS Service center address */

--- a/at_response.c
+++ b/at_response.c
@@ -337,6 +337,7 @@ static int at_response_error (struct pvt* pvt, at_res_t res)
 			case CMD_AT_U2DIAG:
 			case CMD_AT_CCWA_SET:
 			case CMD_AT_CCWA_STATUS:
+			case CMD_AT_CNUM:
 				ast_log (LOG_ERROR, "[%s] Command '%s' failed\n", PVT_ID(pvt), at_cmd2str (ecmd->cmd));
 				/* mean ignore error */
 				break;
@@ -380,11 +381,6 @@ static int at_response_error (struct pvt* pvt, at_res_t res)
 			case CMD_AT_CREG:
 				ast_debug (1, "[%s] Error getting registration info\n", PVT_ID(pvt));
 				break;
-
-			case CMD_AT_CNUM:
-				ast_log (LOG_WARNING, "[%s] Error checking subscriber phone number\n", PVT_ID(pvt));
-				ast_verb (3, "[%s] Dongle needs to be reinitialized. The SIM card is not ready yet\n", PVT_ID(pvt));
-				goto e_return;
 
 			case CMD_AT_CVOICE:
 				ast_debug (1, "[%s] Dongle has NO voice support\n", PVT_ID(pvt));


### PR DESCRIPTION
E3531s-2 returns an AT+CNUM error instead of an empty result. This PR just ignores AT+CNUM errors.