### PR TITLE
Add guard against NULL args.payload

### DIFF
--- a/app.c
+++ b/app.c
@@ -106,6 +106,12 @@ static int app_send_sms_exec (attribute_unused struct ast_channel* channel, cons
 		return -1;
 	}
 
+	if (ast_strlen_zero(args.payload))
+	{
+		ast_log(LOG_ERROR, "NULL payload for message -- SMS will not be sent\n");
+		return -1;
+	}
+
 	if (send_sms(args.device, args.number, args.message, args.validity, args.report, args.payload, strlen(args.payload) + 1) < 0) {
 		ast_log(LOG_ERROR, "[%s] %s\n", args.device, error2str(chan_dongle_err));
 		return -1;


### PR DESCRIPTION
NULL args.payload causes a crash in the call to strlen(args.payload)
while computing arguments for send_sms.