### PR TITLE
Updated interfaces for E171

### DIFF
--- a/pdiscovery.c
+++ b/pdiscovery.c
@@ -66,7 +66,7 @@ static const struct pdiscovery_device device_ids[] = {
 //	{ 0x12d1, 0x1465, { 2, 1, /* 0 */ } },		/* K3520 */
 	{ 0x12d1, 0x140c, { 3, 2, /* 0 */ } },		/* E17xx */
 	{ 0x12d1, 0x1436, { 4, 3, /* 0 */ } },		/* E1750 */
-	{ 0x12d1, 0x1506, { 1, 2, /* 0 */ } },		/* E171 firmware 21.x : thanks Sergey Ivanov */
+	{ 0x12d1, 0x1506, { 3, 2, /* 0 */ } },		/* E171 firmware 21.x : thanks Sergey Ivanov */
 };
 
 static struct discovery_cache cache;


### PR DESCRIPTION
The correct device interfaces for HUAWEI E171 modem is  3,2  . the 1,2 interface order does not work. 

Model: E171
Firmware: 21.156.00.00.143
IMEI: 861496015775578