### PR TITLE
Can Quectel be added?

### DIFF
--- a/at_command.c
+++ b/at_command.c
@@ -33,7 +33,7 @@ static const char cmd_at[] 	 = "AT\r";
 static const char cmd_chld1x[]   = "AT+CHLD=1%d\r";
 static const char cmd_chld2[]    = "AT+CHLD=2\r";
 static const char cmd_clcc[]     = "AT+CLCC\r";
-static const char cmd_ddsetex2[] = "AT^DDSETEX=2\r";
+static const char cmd_ddsetex2[] = "AT+QPCMV=1,0\r";
 
 /*!
  * \brief Format and fill generic command
@@ -128,7 +128,7 @@ EXPORT_DEF int at_enqueue_initialization(struct cpvt *cpvt, at_cmd_t from_comman
 	static const char cmd15[] = "AT+CREG?\r";
 	static const char cmd16[] = "AT+CNUM\r";
 
-	static const char cmd17[] = "AT^CVOICE?\r";
+	static const char cmd17[] = "AT+QPCMV?\r";
 //	static const char cmd18[] = "AT+CLIP=0\r";
 	static const char cmd19[] = "AT+CSSN=1,1\r";
 	static const char cmd20[] = "AT+CMGF=0\r";

--- a/pdiscovery.c
+++ b/pdiscovery.c
@@ -68,6 +68,7 @@ static const struct pdiscovery_device device_ids[] = {
         { 0x12d1, 0x14ac, { 4, 3, /* 0 */ } },          /* E153Du-1 : thanks mghadam */
 	{ 0x12d1, 0x1436, { 4, 3, /* 0 */ } },		/* E1750 */
 	{ 0x12d1, 0x1506, { 3, 2, /* 0 */ } },		/* E171 firmware 21.x : thanks Sergey Ivanov */
+	{ 0x2c7c, 0x0125, { 1, 4, /* 0 */ } },		/* Dongle EC25-A LTE modem */
 };
 
 static struct discovery_cache cache;


### PR DESCRIPTION
Hi Walter,

We received [a pull request](https://github.com/openwrt/telephony/pull/682) to add a new package "asterisk-chan-quectel". It's a fork of your repo: [Link](https://github.com/t4rd15/asterisk-chan-quectel)

I compared the two and the difference is only three lines. Can you somehow integrate this into your repo? I'm not a programmer, also not a chan-dongle user, so highlighting the differences is probably the most I can do myself.

Thanks for taking a look!

Kind regards,
Seb