### PR TITLE
Add initial simcom sim7600 support

### DIFF
--- a/at_command.c
+++ b/at_command.c
@@ -35,6 +35,7 @@ static const char cmd_chld2[]    = "AT+CHLD=2\r";
 static const char cmd_clcc[]     = "AT+CLCC\r";
 static const char cmd_ddsetex2[] = "AT^DDSETEX=2\r";
 static const char cmd_qpcmv10[]  = "AT+QPCMV=1,0\r";
+static const char cmd_cpcmreg0[] = "AT+CPCMREG=0\r";
 
 /*!
  * \brief Format and fill generic command
@@ -151,6 +152,7 @@ EXPORT_DEF int at_enqueue_initialization(struct cpvt *cpvt, at_cmd_t from_comman
 		 * rate, data bit, frame period */
 		ATQ_CMD_DECLARE_STI(CMD_AT_CVOICE, "AT^CVOICE?\r"),
 		ATQ_CMD_DECLARE_STI(CMD_AT_QPCMV, "AT+QPCMV?\r"), /* for Quectel */
+		ATQ_CMD_DECLARE_STI(CMD_AT_CPCMREG, "AT+CPCMREG?\r"), /* for Simcom */
 
 		/* Get SMS Service center address */
 		ATQ_CMD_DECLARE_ST(CMD_AT_CSCA, "AT+CSCA?\r"),
@@ -537,6 +539,8 @@ EXPORT_DEF int at_enqueue_dial(struct cpvt *cpvt, const char *number, int clir)
 
 	if (pvt->has_voice_quectel) {
 		ATQ_CMD_INIT_ST(cmds[cmdsno], CMD_AT_DDSETEX, cmd_qpcmv10);
+	} else if (pvt->has_voice_simcom) {
+		ATQ_CMD_INIT_ST(cmds[cmdsno], CMD_AT_DDSETEX, cmd_cpcmreg0);
 	} else {
 		ATQ_CMD_INIT_ST(cmds[cmdsno], CMD_AT_DDSETEX, cmd_ddsetex2);
 	}
@@ -566,6 +570,8 @@ EXPORT_DEF int at_enqueue_answer(struct cpvt *cpvt)
 	ATQ_CMD_INIT_DYN(cmds[0], CMD_AT_A);
 	if (pvt->has_voice_quectel) {
 		ATQ_CMD_INIT_ST(cmds[1], CMD_AT_DDSETEX, cmd_qpcmv10);
+	} else if (pvt->has_voice_simcom) {
+		ATQ_CMD_INIT_ST(cmds[1], CMD_AT_DDSETEX, cmd_cpcmreg0);
 	} else {
 		ATQ_CMD_INIT_ST(cmds[1], CMD_AT_DDSETEX, cmd_ddsetex2);
 	}

--- a/at_command.c
+++ b/at_command.c
@@ -390,6 +390,7 @@ EXPORT_DEF int at_enqueue_ussd(struct cpvt *cpvt, const char *code)
 
 EXPORT_DEF int at_enqueue_dtmf(struct cpvt *cpvt, char digit)
 {
+	struct pvt *pvt = cpvt->pvt;
 	switch (digit)
 	{
 /* unsupported, but AT^DTMF=1,22 OK and "2" sent
@@ -416,7 +417,11 @@ EXPORT_DEF int at_enqueue_dtmf(struct cpvt *cpvt, char digit)
 
 		case '*':
 		case '#':
-			return at_enqueue_generic(cpvt, CMD_AT_DTMF, 1, "AT^DTMF=%d,%c\r", cpvt->call_idx, digit);
+			if (pvt->has_voice_simcom) {
+				return at_enqueue_generic(cpvt, CMD_AT_DTMF, 1, "AT+VTS=%c\r", digit);
+			} else {
+				return at_enqueue_generic(cpvt, CMD_AT_DTMF, 1, "AT^DTMF=%d,%c\r", cpvt->call_idx, digit);
+			}
 	}
 	return -1;
 }

--- a/at_command.h
+++ b/at_command.h
@@ -65,6 +65,8 @@
 	_( AT_DDSETEX,      "AT^DDSETEX") \
 	/* same, but for Quectel EC25 */ \
 	_( AT_QPCMV,        "AT+QPCMV") \
+	/* for Simcom SIM7600 */ \
+	_( AT_CPCMREG,      "AT+CPCMREG") \
 	_( AT_DTMF,         "AT^DTMF") \
 	_( AT_E,            "ATE") \
 \

--- a/at_response.c
+++ b/at_response.c
@@ -126,11 +126,19 @@ static int at_response_ok (struct pvt* pvt, at_res_t res)
 				ast_debug (1, "[%s] Dongle has voice support\n", PVT_ID(pvt));
 				pvt->has_voice = 1;
 				pvt->has_voice_quectel = 0;
+				pvt->has_voice_simcom= 0;
 				break;
 			case CMD_AT_QPCMV:
 				ast_debug (1, "[%s] Dongle has Quectel voice support\n", PVT_ID(pvt));
 				pvt->has_voice = 1;
 				pvt->has_voice_quectel = 1;
+				pvt->has_voice_simcom= 0;
+				break;
+			case CMD_AT_CPCMREG:
+				ast_debug (1, "[%s] Dongle has Simcom voice support\n", PVT_ID(pvt));
+				pvt->has_voice = 1;
+				pvt->has_voice_quectel = 0;
+				pvt->has_voice_simcom= 1;
 				break;
 /*
 			case CMD_AT_CLIP:
@@ -370,8 +378,12 @@ static int at_response_error (struct pvt* pvt, at_res_t res)
 			case CMD_AT_QPCMV:
 				ast_debug(1, "[%s] Dongle has NO (QPCMV) voice support\n", PVT_ID(pvt));
 				pvt->has_voice_quectel = 0;
+				break;
+			case CMD_AT_CPCMREG:
+				ast_debug(1, "[%s] Dongle has NO (CPCMREG) voice support\n", PVT_ID(pvt));
+				pvt->has_voice_simcom = 0;
 
-				if (pvt->has_voice == 0) {
+				if (pvt->has_voice == 0 && pvt->has_voice_quectel == 0) {
 					ast_log(LOG_WARNING, "[%s] Dongle has NO voice support\n", PVT_ID(pvt));
 				}
 				break;

--- a/chan_dongle.h
+++ b/chan_dongle.h
@@ -181,6 +181,7 @@ typedef struct pvt
 	unsigned int		has_sms:1;			/*!< device has SMS support */
 	unsigned int		has_voice:1;			/*!< device has voice call support */
 	unsigned int		has_voice_quectel:1;		/*!< device has Quectel voice call support */
+	unsigned int		has_voice_simcom:1;		/*!< device has Simcom voice call support */
 	unsigned int		has_call_waiting:1;		/*!< call waiting enabled on device */
 
 	unsigned int		group_last_used:1;		/*!< mark the last used device */

--- a/pdiscovery.c
+++ b/pdiscovery.c
@@ -69,6 +69,7 @@ static const struct pdiscovery_device device_ids[] = {
 	{ 0x12d1, 0x1436, { 4, 3, /* 0 */ } },		/* E1750 */
 	{ 0x12d1, 0x1506, { 3, 2, /* 0 */ } },		/* E171 firmware 21.x : thanks Sergey Ivanov */
 	{ 0x2c7c, 0x0125, { 1, 4, /* 0 */ } },		/* Dongle EC25-A LTE modem */
+	{ 0x1e0e, 0x9001, { 2, 4, /* 0 */ } },          /* Simcom Sim7600 */
 };
 
 static struct discovery_cache cache;


### PR DESCRIPTION
Initializes a sim7600 dongle correctly. 
Voice calls still don't work completely as sim7600 requires setting `AT+CPCMREG=1` just as the call is connected and 0,1 on disconnect.

If someone wants to add the remaining functionality the following docs should help:
https://www.waveshare.net/w/upload/8/8f/SIM7500_SIM7600_Series_AT_Command_Manual_V1.12.pdf
https://www.quectel.com/wp-content/uploads/pdfupload/Quectel_EC2x&EG9x&EG2x-G&EM05_Series_AT_Commands_Manual_V2.0.pdf
