### PR TITLE
Consider long long (lld) for time_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,11 +165,13 @@ dnl AC_CHECK_TYPE(uint64_t, unsigned long long)
 
 AC_CHECK_SIZEOF(int)
 AC_CHECK_SIZEOF(long int)
+AC_CHECK_SIZEOF(long long int)
 AC_CHECK_SIZEOF(time_t)
 case "$ac_cv_sizeof_time_t" in
 ''|0) AC_MSG_ERROR([Could not find time_t type]);;
 $ac_cv_sizeof_int) AC_DEFINE([PRI_time_t], ["d"], [printf format for time_t]);;
 $ac_cv_sizeof_long_int) AC_DEFINE([PRI_time_t], ["ld"], [printf format for time_t]);;
+$ac_cv_sizeof_long_long_int) AC_DEFINE([PRI_time_t], ["lld"], [printf format for time_t]);;
 *) AC_MSG_ERROR([Could not find match size of time_t to printf format])
 esac
 


### PR DESCRIPTION
Hi all,

I was getting ready to bump the OpenWrt package to the latest git, only to find this error:

```
checking for ssize_t... (cached) yes
checking for uint64_t... yes
checking size of int... (cached) 4
checking size of long int... (cached) 4
checking size of time_t... 8
configure: error: Could not find match size of time_t to printf format
```

We've seen similar issues in the past in OpenWrt, after musl was updated to 1.2.

Some libc implementations are shifting toward using 64-bit time_t for all arches to solve the year 2038 problem. musl is one of them, see [1].

So when compiling for a 32-bit arch time_t will be long long. This commit adds this option.

[1] https://musl.libc.org/time64.html