### PR TITLE
SMS received containing Turkish chars gets scrambled

### DIFF
--- a/pdu.c
+++ b/pdu.c
@@ -901,13 +901,15 @@ EXPORT_DEF int tpdu_parse_deliver(const uint8_t *pdu, size_t pdu_length, int tpd
 						return -1;
 					}
 					udh->ss = pdu[i++];
+					udhl -= 1; /* consume the 1 data byte from udhl budget */
 					break;
-				case 0x25: /* National Language Single Shift */
+				case 0x25: /* National Language Locking Shift (e.g. Turkish = 1) */
 					if (iei_len != 1) {
 						chan_dongle_err = E_UNKNOWN;
 						return -1;
 					}
 					udh->ls = pdu[i++];
+					udhl -= 1; /* consume the 1 data byte from udhl budget */
 					break;
 				default:
 					/* skip rest of IEI */


### PR DESCRIPTION
IEI 0x24 (Single Shift) and IEI 0x25 (Locking Shift) are the headers that carry the Turkish language table number. The while (udhl >= 2) loop tracks how many UDH bytes remain in udhl. For every IEI, it decrements udhl by 2 (for the type+length bytes), and for IEI data bytes, each case must further decrement by iei_len. The default case did this correctly (udhl -= iei_len), and so did case 0x00 and case 0x08 — but cases 0x24 and 0x25 were missing their udhl -= 1.

after the loop, i += udhl skipped one extra byte of actual message data, corrupting all decoded text whenever Turkish language tables were present. A single-byte shift caused every character to decode from the wrong position.

Added udhl -= 1; (= udhl -= iei_len) after reading the data byte in both case 0x24 and case 0x25. Also corrected the wrong comment on 0x25 (it's "Locking Shift", not "Single Shift").